### PR TITLE
Fix JWT encoder/decoder key mismatch

### DIFF
--- a/spec/app/graphql/mutations/login_user_spec.rb
+++ b/spec/app/graphql/mutations/login_user_spec.rb
@@ -4,7 +4,6 @@ describe 'Mutations::LoginUser', type: :request do
   include_context 'with GraphQL Client'
 
   let(:user) { create(:user) }
-
   let(:query) do
     <<~GQL
       mutation LoginUser($email: String!, $password: String!) {
@@ -21,14 +20,6 @@ describe 'Mutations::LoginUser', type: :request do
       query,
       { email: user.email, password: user.password }
     )
-  end
-
-  context 'when credentials are valid' do
-    it 'returns JWT and User ID' do
-      expect(graph_response['data']['loginUser']['userId']).to eq(user.id.to_s)
-      expect(graph_response['data']['loginUser']['token']).to be_present
-      expect(response).to have_http_status(:ok)
-    end
   end
 
   context 'when credentials are invalid' do
@@ -65,6 +56,22 @@ describe 'Mutations::LoginUser', type: :request do
       expect(graph_response['data']['loginUser']).to be_nil
       expect(graph_response['errors'].first['message'])
         .to eq('Invalid email or password')
+    end
+  end
+
+  context 'when credentials are valid' do
+    it 'returns JWT and User ID' do
+      expect(graph_response['data']['loginUser']['userId']).to eq(user.id.to_s)
+      expect(graph_response['data']['loginUser']['token']).to be_present
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns a token that is decodable and points to the correct user' do
+      token = graph_response['data']['loginUser']['token']
+      decoded_user = Auth::JwtDecoder.call("Bearer #{token}")
+
+      expect(decoded_user).not_to be_nil
+      expect(decoded_user.id).to eq(user.id)
     end
   end
 end


### PR DESCRIPTION
Error was caught when testing via Altair (Firefox)

`LoginUser` was generating tokens via `User#generate_auth_token` (signed with `secret_key_base`) while `JwtDecoder` verified against `credentials.dig(:jwt, :secret)`. Standardized the full auth flow to use `Auth::JwtEncoder`.

Added spec asserting the login token is decodable by `JwtDecoder`.