### PR TITLE
[movie_review] feat: allow user to update movie review

### DIFF
--- a/app/graphql/mutations/update_movie_review.rb
+++ b/app/graphql/mutations/update_movie_review.rb
@@ -1,0 +1,26 @@
+module Mutations
+  class UpdateMovieReview < Mutations::BaseMutation
+    argument :movie_id, String, required: true
+    argument :review, String, required: false
+
+    field :errors, [String], null: false
+    field :movie, Types::MovieType, null: true
+
+    def resolve(movie_id:, review:)
+      authenticate_user!
+
+      day = current_user.days.where('movies._id' => movie_id).first
+      raise GraphQL::ExecutionError, 'Record not found' unless day
+
+      movie = day.movies.where(_id: movie_id).first
+      raise GraphQL::ExecutionError, 'Record not found' unless movie
+
+      success = movie.update(review: review)
+
+      {
+        movie: success ? movie : nil,
+        errors: success ? [] : movie.errors.full_messages
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -8,6 +8,7 @@ module Types
     field :add_user, mutation: Mutations::AddUser
     field :toggle_affirmation, mutation: Mutations::ToggleAffirmation
     field :login_user, mutation: Mutations::LoginUser
+    field :update_movie_review, mutation: Mutations::UpdateMovieReview
     field :update_todo, mutation: Mutations::UpdateTodo
   end
 end

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -10,7 +10,6 @@ development:
     default:
       uri: <%= ENV['MONGODB_URI'] %>
       options:
-        database: writeonapi
         direct_connection: true
 
 test:

--- a/spec/app/graphql/mutations/update_movie_review_mutation_spec.rb
+++ b/spec/app/graphql/mutations/update_movie_review_mutation_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe 'Update Movie review mutation', type: :request do
+  include_context 'with GraphQL Client'
+
+  let!(:user) { create(:user) }
+  let!(:day) { create(:day, :with_movies, user: user) }
+  let(:to_be_updated) { build(:movie, review: "I'm updated") }
+  let(:new_movie) { build(:movie) }
+  let(:query) do
+    <<-GRAPHQL
+      mutation UpdateMovieReview($movieId: String!, $review: String) {
+        updateMovieReview(
+          input: { movieId: $movieId review: $review }) {
+          errors
+          movie {
+            id
+            title
+            review
+          }
+        }
+      }
+    GRAPHQL
+  end
+
+  context 'when movie review is updated successfully' do
+    before do
+      post_graph(query, {
+                   movieId: day.movies.first.id.to_s,
+                   review: to_be_updated.review
+                 }, context: { current_user: user })
+    end
+
+    it 'displays the correct data' do
+      expect(graph_response['data']['updateMovieReview']['movie']).to include(
+        'title' => day.movies.first.title,
+        'review' => to_be_updated.review
+      )
+    end
+  end
+
+  context 'when movie is not found' do
+    before do
+      post_graph(query,
+                 { movieId: 'invalid_id',
+                   review: to_be_updated.review },
+                 context: { current_user: user })
+    end
+
+    it 'returns an error' do
+      expect(graph_response['errors'].first['message']).to eq('Record not found')
+    end
+  end
+
+  context 'when user is not authenticated' do
+    before do
+      post_graph(query, {
+                   movieId: new_movie.id.to_s,
+                   review: new_movie.review
+                 })
+    end
+
+    it 'returns a not authenticated error' do
+      expect(graph_response['errors'].first['message']).to eq('Not authenticated')
+    end
+  end
+end


### PR DESCRIPTION
Implements a GraphQL mutation to update a movie review within a day. The mutation validates authentication, ensures the movie belongs to the current user, and updates the review field, allowing it to be set or cleared.